### PR TITLE
Generalize postpone to manipulate any tag

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10956,12 +10956,13 @@ Business days only take Monday - Friday into account.</pre>
 <pre>Postpone the todo item(s) with the given number(s) and the given pattern.
 
 ```
-postpone [-s] &lt;NUMBER&gt; [&lt;NUMBER2&gt; ...] &lt;PATTERN&gt;&quot;
+postpone [-s [-s]] &lt;NUMBER&gt; [&lt;NUMBER2&gt; ...] &lt;PATTERN&gt;&quot;
 postpone [-x] -e &lt;EXPRESSION&gt;
 ```
 
 Postponing is done by adjusting the [[due date(s)|TagDue]] of the todo(s), and if the `-s`
 flag is given, the [[start date|TagStart]] accordingly.
+If the `-s` flag is repeated, only the [[start date|TagStart]] is adjusted.
 
 It is also possible to postpone items with an expression using
 the `-e` flag. Use `-x` to also process todo items that are normally invisible

--- a/docs/index.html
+++ b/docs/index.html
@@ -10956,13 +10956,14 @@ Business days only take Monday - Friday into account.</pre>
 <pre>Postpone the todo item(s) with the given number(s) and the given pattern.
 
 ```
-postpone [-s [-s]] &lt;NUMBER&gt; [&lt;NUMBER2&gt; ...] &lt;PATTERN&gt;&quot;
+postpone [-s] [-t &lt;TAG&gt;] [-T &lt;TAG&gt;] &lt;NUMBER&gt; [&lt;NUMBER2&gt; ...] &lt;PATTERN&gt;&quot;
 postpone [-x] -e &lt;EXPRESSION&gt;
 ```
 
 Postponing is done by adjusting the [[due date(s)|TagDue]] of the todo(s), and if the `-s`
 flag is given, the [[start date|TagStart]] accordingly.
-If the `-s` flag is repeated, only the [[start date|TagStart]] is adjusted.
+If the -t flag is given adjustment is applied to TAG. If the -T flag is
+given adjustment is applied to TAG under the condition that it exists.
 
 It is also possible to postpone items with an expression using
 the `-e` flag. Use `-x` to also process todo items that are normally invisible

--- a/test/test_postpone_command.py
+++ b/test/test_postpone_command.py
@@ -313,7 +313,7 @@ class PostponeCommandTest(CommandTest):
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.output, "|  1| Foo\n")
-        self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.")
+        self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.\n")
 
     def test_postpone26(self):
         command = PostponeCommand(["-T", "t", "1", "1w"], self.todolist, self.out,
@@ -322,7 +322,7 @@ class PostponeCommandTest(CommandTest):
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.output, "|  1| Foo\n")
-        self.assertEqual(self.errors, "Warning: todo item has no (valid) t date, therefore it was not adjusted.")
+        self.assertEqual(self.errors, "Warning: todo item has no (valid) t date, therefore it was not adjusted.\n")
 
     def test_postpone27(self):
         command = PostponeCommand(["-t", "due", "2", "1w"], self.todolist, self.out,
@@ -354,7 +354,7 @@ class PostponeCommandTest(CommandTest):
         due = self.today + timedelta(7)
 
         self.assertTrue(self.todolist.dirty)
-        self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(due.isoformat(), self.today.isoformat()))
+        self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(due.isoformat(), self.start.isoformat()))
         self.assertEqual(self.errors, "")
 
     def test_postpone30(self):
@@ -365,7 +365,7 @@ class PostponeCommandTest(CommandTest):
         due = self.today + timedelta(7)
 
         self.assertTrue(self.todolist.dirty)
-        self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(due.isoformat(), self.today.isoformat()))
+        self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(due.isoformat(), self.start.isoformat()))
         self.assertEqual(self.errors, "")
 
     def test_postpone31(self):
@@ -376,7 +376,7 @@ class PostponeCommandTest(CommandTest):
         due = self.today + timedelta(7)
 
         self.assertTrue(self.todolist.dirty)
-        self.assertEqual(self.output, "|  4| Past due:{} t:{}\n".format(due.isoformat()))
+        self.assertEqual(self.output, "|  4| Past due:{}\n".format(due.isoformat()))
         self.assertEqual(self.errors, "")
 
     def test_postpone32(self):
@@ -387,7 +387,7 @@ class PostponeCommandTest(CommandTest):
         due = self.today + timedelta(7)
 
         self.assertTrue(self.todolist.dirty)
-        self.assertEqual(self.output, "|  4| Past due:{} t:{}\n".format(due.isoformat()))
+        self.assertEqual(self.output, "|  4| Past due:{}\n".format(due.isoformat()))
         self.assertEqual(self.errors, "")
 
     def test_postpone33(self):
@@ -417,7 +417,7 @@ class PostponeCommandTest(CommandTest):
                                   self.error)
         command.execute()
 
-        t = self.future_start + timedelta(7)
+        t = self.today + timedelta(7)
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.output, "|  5| Future due:{} t:{}\n".format(self.future.isoformat(), t.isoformat()))
@@ -441,7 +441,7 @@ class PostponeCommandTest(CommandTest):
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.output, "|  6| FutureStart t:{}\n".format(self.future.isoformat()))
-        self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.")
+        self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.\n")
 
     def test_postpone38(self):
         command = PostponeCommand(["-t", "t", "6", "1w"], self.todolist, self.out,
@@ -480,7 +480,7 @@ class PostponeCommandTest(CommandTest):
         due = self.today + timedelta(7)
 
         self.assertTrue(self.todolist.dirty)
-        self.assertEqual(self.output, "|  8| InvalidStartDate due:{} t:2017-06-31\n".format(due.isoformat()))
+        self.assertEqual(self.output, "|  8| InvalidStartDate t:2017-06-31 due:{}\n".format(due.isoformat()))
         self.assertEqual(self.errors, "")
 
     def test_postpone42(self):
@@ -490,7 +490,7 @@ class PostponeCommandTest(CommandTest):
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.output, "|  8| InvalidStartDate t:2017-06-31\n")
-        self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.")
+        self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.\n")
 
     def test_expr_postpone1(self):
         command = PostponeCommand(["-e", "due:tod", "2w"], self.todolist,

--- a/test/test_postpone_command.py
+++ b/test/test_postpone_command.py
@@ -492,6 +492,171 @@ class PostponeCommandTest(CommandTest):
         self.assertEqual(self.output, "|  8| InvalidStartDate t:2017-06-31\n")
         self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.\n")
 
+    def test_postpone43(self):
+        command = PostponeCommand(["-t", "due", "-t", "t", "1", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7) # start = due
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  1| Foo due:{} t:{}\n".format(due.isoformat(), due.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone44(self):
+        command = PostponeCommand(["-t", "t", "-t", "due", "1", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7) # start = due
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  1| Foo due:{} t:{}\n".format(due.isoformat(), due.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone45(self):
+        command = PostponeCommand(["-t", "due", "-T", "t", "1", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  1| Foo due:{}\n".format(due.isoformat()))
+        self.assertEqual(self.errors, "Warning: todo item has no (valid) t date, therefore it was not adjusted.\n")
+
+    def test_postpone46(self):
+        command = PostponeCommand(["-T", "due", "-t", "t", "1", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        start = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  1| Foo t:{}\n".format(start.isoformat()))
+        self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.\n")
+
+    def test_postpone47(self):
+        command = PostponeCommand(["-T", "due", "-T", "t", "1", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        start = self.today + timedelta(7)
+
+        self.assertFalse(self.todolist.dirty)
+        self.assertEqual(self.output, "|  1| Foo\n")
+        self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.\nWarning: todo item has no (valid) t date, therefore it was not adjusted.\n")
+
+    def test_postpone48(self):
+        command = PostponeCommand(["-t", "due", "-T", "t", "3", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7) # start = due
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(due.isoformat(), due.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone49(self):
+        command = PostponeCommand(["-T", "due", "-t", "t", "3", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7) # start = due
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(due.isoformat(), due.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone50(self):
+        command = PostponeCommand(["-T", "due", "-T", "t", "3", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7) # start = due
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(due.isoformat(), due.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone51(self):
+        command = PostponeCommand(["-t", "due", "-t", "due", "1", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  1| Foo due:{}\n".format(due.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone52(self):
+        command = PostponeCommand(["-t", "due", "-t", "t", "-t", "due", "1", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7) # start = due
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  1| Foo due:{} t:{}\n".format(due.isoformat(), due.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone53(self):
+        command = PostponeCommand(["-t", "due", "-T", "t", "-T", "t", "3", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7) # start = due
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(due.isoformat(), due.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone54(self):
+        command = PostponeCommand(["-t", "due", "-T", "t", "-t", "t", "3", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7) # start = due
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(due.isoformat(), due.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone55(self):
+        command = PostponeCommand(["-t", "due", "-t", "t", "-T", "t", "3", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7) # start = due
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(due.isoformat(), due.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone56(self):
+        command = PostponeCommand(["-t", "due", "-t", "t", "-T", "t", "1", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  1| Foo due:{}\n".format(due.isoformat()))
+        self.assertEqual(self.errors, "Warning: todo item has no (valid) t date, therefore it was not adjusted.\n")
+
+    def test_postpone57(self):
+        command = PostponeCommand(["-t", "due", "-T", "t", "-t", "t", "1", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  1| Foo due:{}\n".format(due.isoformat()))
+        self.assertEqual(self.errors, "Warning: todo item has no (valid) t date, therefore it was not adjusted.\n")
+
     def test_expr_postpone1(self):
         command = PostponeCommand(["-e", "due:tod", "2w"], self.todolist,
                                   self.out, self.error, None)

--- a/test/test_postpone_command.py
+++ b/test/test_postpone_command.py
@@ -311,7 +311,7 @@ class PostponeCommandTest(CommandTest):
                                   self.error)
         command.execute()
 
-        self.assertTrue(self.todolist.dirty)
+        self.assertFalse(self.todolist.dirty)
         self.assertEqual(self.output, "|  1| Foo\n")
         self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.\n")
 
@@ -320,7 +320,7 @@ class PostponeCommandTest(CommandTest):
                                   self.error)
         command.execute()
 
-        self.assertTrue(self.todolist.dirty)
+        self.assertFalse(self.todolist.dirty)
         self.assertEqual(self.output, "|  1| Foo\n")
         self.assertEqual(self.errors, "Warning: todo item has no (valid) t date, therefore it was not adjusted.\n")
 
@@ -439,7 +439,7 @@ class PostponeCommandTest(CommandTest):
                                   self.error)
         command.execute()
 
-        self.assertTrue(self.todolist.dirty)
+        self.assertFalse(self.todolist.dirty)
         self.assertEqual(self.output, "|  6| FutureStart t:{}\n".format(self.future.isoformat()))
         self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.\n")
 
@@ -488,7 +488,7 @@ class PostponeCommandTest(CommandTest):
                                   self.error)
         command.execute()
 
-        self.assertTrue(self.todolist.dirty)
+        self.assertFalse(self.todolist.dirty)
         self.assertEqual(self.output, "|  8| InvalidStartDate t:2017-06-31\n")
         self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.\n")
 

--- a/test/test_postpone_command.py
+++ b/test/test_postpone_command.py
@@ -344,7 +344,7 @@ class PostponeCommandTest(CommandTest):
                 "|  2| Bar due:{} t:{}\n".format(self.today.isoformat(), start.isoformat()))
         self.assertEqual(self.errors, "")
 
-    def test_postpone27(self):
+    def test_postpone28(self):
         command = PostponeCommand(["-s", "-s", "3", "1w"], self.todolist, self.out,
                                   self.error)
         command.execute()
@@ -356,7 +356,7 @@ class PostponeCommandTest(CommandTest):
         self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(self.today.isoformat(), start.isoformat()))
         self.assertEqual(self.errors, "")
 
-    def test_postpone28(self):
+    def test_postpone29(self):
         command = PostponeCommand(["-s", "-s", "2", "3", "1w"], self.todolist,
                                   self.out, self.error)
         command.execute()
@@ -368,7 +368,7 @@ class PostponeCommandTest(CommandTest):
         self.assertEqual(self.output, "|  2| Bar due:{} t:{}\n|  3| Baz due:{} t:{}\n".format(self.today.isoformat(), start.isoformat(), self.today.isoformat(), start.isoformat()))
         self.assertEqual(self.errors, "")
 
-    def test_postpone29(self):
+    def test_postpone30(self):
         command = PostponeCommand(["-s", "-s", "5", "1w"], self.todolist, self.out,
                                   self.error)
         command.execute()
@@ -380,7 +380,7 @@ class PostponeCommandTest(CommandTest):
         self.assertEqual(self.output, "|  5| Future due:{} t:{}\n".format(self.future.isoformat(), start.isoformat()))
         self.assertEqual(self.errors, "")
 
-    def test_postpone30(self):
+    def test_postpone31(self):
         command = PostponeCommand(["-s", "-s", "7", "1w"], self.todolist, self.out, self.error)
         command.execute()
 
@@ -390,7 +390,7 @@ class PostponeCommandTest(CommandTest):
         self.assertEqual(self.output, "|  7| InvalidDueDate due:2017-06-31 t:{}\n".format(start.isoformat()))
         self.assertEqual(self.errors, "")
 
-    def test_postpone31(self):
+    def test_postpone32(self):
         """
         Todo item has an invalid start date.
         """

--- a/test/test_postpone_command.py
+++ b/test/test_postpone_command.py
@@ -655,6 +655,24 @@ class PostponeCommandTest(CommandTest):
         self.assertEqual(self.output, "|  1| Foo due:{}\n".format(due.isoformat()))
         self.assertEqual(self.errors, "Warning: todo item has no (valid) t date, therefore it was not adjusted.\n")
 
+    def test_postpone58(self):
+        command = PostponeCommand(["-t", "due", "1", "foo"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        self.assertFalse(self.todolist.dirty)
+        self.assertEqual(self.output, "")
+        self.assertEqual(self.errors, "Invalid date pattern given.\n")
+
+    def test_postpone59(self):
+        command = PostponeCommand(["-T", "due", "1", "foo"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        self.assertFalse(self.todolist.dirty)
+        self.assertEqual(self.output, "")
+        self.assertEqual(self.errors, "Invalid date pattern given.\n")
+
     def test_expr_postpone1(self):
         command = PostponeCommand(["-e", "due:tod", "2w"], self.todolist,
                                   self.out, self.error, None)

--- a/test/test_postpone_command.py
+++ b/test/test_postpone_command.py
@@ -295,6 +295,111 @@ class PostponeCommandTest(CommandTest):
         self.assertEqual(self.output, "|  8| InvalidStartDate t:2017-06-31 due:{}\n".format(self.future.isoformat()))
         self.assertEqual(self.errors, "Warning: todo item has no (valid) start date, therefore it was not adjusted.\n")
 
+    def test_postpone24(self):
+        command = PostponeCommand(["-s", "-s", "1", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        start = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        # pylint: disable=E1103
+        self.assertEqual(self.output, "|  1| Foo t:{}\n".format(start.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone25(self):
+        command = PostponeCommand(["-s", "-s", "6", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        start = self.future + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        # pylint: disable=E1103
+        self.assertEqual(self.output, "|  6| FutureStart t:{}\n".format(start.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone26(self):
+        """ -ss instead of -s -s. """
+        command = PostponeCommand(["-ss", "6", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        start = self.future + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        # pylint: disable=E1103
+        self.assertEqual(self.output, "|  6| FutureStart t:{}\n".format(start.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone27(self):
+        command = PostponeCommand(["-s", "-s", "2", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        start = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output,
+                "|  2| Bar due:{} t:{}\n".format(self.today.isoformat(), start.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone27(self):
+        command = PostponeCommand(["-s", "-s", "3", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        start = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        # pylint: disable=E1103
+        self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(self.today.isoformat(), start.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone28(self):
+        command = PostponeCommand(["-s", "-s", "2", "3", "1w"], self.todolist,
+                                  self.out, self.error)
+        command.execute()
+
+        start = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        # pylint: disable=E1103
+        self.assertEqual(self.output, "|  2| Bar due:{} t:{}\n|  3| Baz due:{} t:{}\n".format(self.today.isoformat(), start.isoformat(), self.today.isoformat(), start.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone29(self):
+        command = PostponeCommand(["-s", "-s", "5", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        start = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        # pylint: disable=E1103
+        self.assertEqual(self.output, "|  5| Future due:{} t:{}\n".format(self.future.isoformat(), start.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone30(self):
+        command = PostponeCommand(["-s", "-s", "7", "1w"], self.todolist, self.out, self.error)
+        command.execute()
+
+        start = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  7| InvalidDueDate due:2017-06-31 t:{}\n".format(start.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone31(self):
+        """
+        Todo item has an invalid start date.
+        """
+        command = PostponeCommand(["-s", "-s", "8", "1d"], self.todolist, self.out, self.error)
+        command.execute()
+
+        self.assertFalse(self.todolist.dirty)
+        self.assertEqual(self.errors, "Postponing todo item failed: invalid start date.\n")
+
     def test_expr_postpone1(self):
         command = PostponeCommand(["-e", "due:tod", "2w"], self.todolist,
                                   self.out, self.error, None)

--- a/test/test_postpone_command.py
+++ b/test/test_postpone_command.py
@@ -541,8 +541,6 @@ class PostponeCommandTest(CommandTest):
                                   self.error)
         command.execute()
 
-        start = self.today + timedelta(7)
-
         self.assertFalse(self.todolist.dirty)
         self.assertEqual(self.output, "|  1| Foo\n")
         self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.\nWarning: todo item has no (valid) t date, therefore it was not adjusted.\n")

--- a/test/test_postpone_command.py
+++ b/test/test_postpone_command.py
@@ -296,109 +296,201 @@ class PostponeCommandTest(CommandTest):
         self.assertEqual(self.errors, "Warning: todo item has no (valid) start date, therefore it was not adjusted.\n")
 
     def test_postpone24(self):
-        command = PostponeCommand(["-s", "-s", "1", "1w"], self.todolist, self.out,
+        command = PostponeCommand(["-t", "due", "1", "1w"], self.todolist, self.out,
                                   self.error)
         command.execute()
 
-        start = self.today + timedelta(7)
+        due = self.today + timedelta(7)
 
         self.assertTrue(self.todolist.dirty)
-        # pylint: disable=E1103
-        self.assertEqual(self.output, "|  1| Foo t:{}\n".format(start.isoformat()))
+        self.assertEqual(self.output, "|  1| Foo due:{}\n".format(due.isoformat()))
         self.assertEqual(self.errors, "")
 
     def test_postpone25(self):
-        command = PostponeCommand(["-s", "-s", "6", "1w"], self.todolist, self.out,
+        command = PostponeCommand(["-T", "due", "1", "1w"], self.todolist, self.out,
                                   self.error)
         command.execute()
 
-        start = self.future + timedelta(7)
-
         self.assertTrue(self.todolist.dirty)
-        # pylint: disable=E1103
-        self.assertEqual(self.output, "|  6| FutureStart t:{}\n".format(start.isoformat()))
-        self.assertEqual(self.errors, "")
+        self.assertEqual(self.output, "|  1| Foo\n")
+        self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.")
 
     def test_postpone26(self):
-        """ -ss instead of -s -s. """
-        command = PostponeCommand(["-ss", "6", "1w"], self.todolist, self.out,
+        command = PostponeCommand(["-T", "t", "1", "1w"], self.todolist, self.out,
                                   self.error)
         command.execute()
 
-        start = self.future + timedelta(7)
-
         self.assertTrue(self.todolist.dirty)
-        # pylint: disable=E1103
-        self.assertEqual(self.output, "|  6| FutureStart t:{}\n".format(start.isoformat()))
-        self.assertEqual(self.errors, "")
+        self.assertEqual(self.output, "|  1| Foo\n")
+        self.assertEqual(self.errors, "Warning: todo item has no (valid) t date, therefore it was not adjusted.")
 
     def test_postpone27(self):
-        command = PostponeCommand(["-s", "-s", "2", "1w"], self.todolist, self.out,
+        command = PostponeCommand(["-t", "due", "2", "1w"], self.todolist, self.out,
                                   self.error)
         command.execute()
 
-        start = self.today + timedelta(7)
+        due = self.today + timedelta(7)
 
         self.assertTrue(self.todolist.dirty)
-        self.assertEqual(self.output,
-                "|  2| Bar due:{} t:{}\n".format(self.today.isoformat(), start.isoformat()))
+        self.assertEqual(self.output, "|  2| Bar due:{}\n".format(due.isoformat()))
         self.assertEqual(self.errors, "")
 
     def test_postpone28(self):
-        command = PostponeCommand(["-s", "-s", "3", "1w"], self.todolist, self.out,
+        command = PostponeCommand(["-T", "due", "2", "1w"], self.todolist, self.out,
                                   self.error)
         command.execute()
 
-        start = self.today + timedelta(7)
+        due = self.today + timedelta(7)
 
         self.assertTrue(self.todolist.dirty)
-        # pylint: disable=E1103
-        self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(self.today.isoformat(), start.isoformat()))
+        self.assertEqual(self.output, "|  2| Bar due:{}\n".format(due.isoformat()))
         self.assertEqual(self.errors, "")
 
     def test_postpone29(self):
-        command = PostponeCommand(["-s", "-s", "2", "3", "1w"], self.todolist,
-                                  self.out, self.error)
-        command.execute()
-
-        start = self.today + timedelta(7)
-
-        self.assertTrue(self.todolist.dirty)
-        # pylint: disable=E1103
-        self.assertEqual(self.output, "|  2| Bar due:{} t:{}\n|  3| Baz due:{} t:{}\n".format(self.today.isoformat(), start.isoformat(), self.today.isoformat(), start.isoformat()))
-        self.assertEqual(self.errors, "")
-
-    def test_postpone30(self):
-        command = PostponeCommand(["-s", "-s", "5", "1w"], self.todolist, self.out,
+        command = PostponeCommand(["-t", "due", "3", "1w"], self.todolist, self.out,
                                   self.error)
         command.execute()
 
-        start = self.today + timedelta(7)
+        due = self.today + timedelta(7)
 
         self.assertTrue(self.todolist.dirty)
-        # pylint: disable=E1103
-        self.assertEqual(self.output, "|  5| Future due:{} t:{}\n".format(self.future.isoformat(), start.isoformat()))
+        self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(due.isoformat(), self.today.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone30(self):
+        command = PostponeCommand(["-T", "due", "3", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  3| Baz due:{} t:{}\n".format(due.isoformat(), self.today.isoformat()))
         self.assertEqual(self.errors, "")
 
     def test_postpone31(self):
-        command = PostponeCommand(["-s", "-s", "7", "1w"], self.todolist, self.out, self.error)
+        command = PostponeCommand(["-t", "due", "4", "1w"], self.todolist, self.out,
+                                  self.error)
         command.execute()
 
-        start = self.today + timedelta(7)
+        due = self.today + timedelta(7)
 
         self.assertTrue(self.todolist.dirty)
-        self.assertEqual(self.output, "|  7| InvalidDueDate due:2017-06-31 t:{}\n".format(start.isoformat()))
+        self.assertEqual(self.output, "|  4| Past due:{} t:{}\n".format(due.isoformat()))
         self.assertEqual(self.errors, "")
 
     def test_postpone32(self):
-        """
-        Todo item has an invalid start date.
-        """
-        command = PostponeCommand(["-s", "-s", "8", "1d"], self.todolist, self.out, self.error)
+        command = PostponeCommand(["-T", "due", "4", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  4| Past due:{} t:{}\n".format(due.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone33(self):
+        command = PostponeCommand(["-t", "due", "5", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.future + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  5| Future due:{} t:{}\n".format(due.isoformat(), self.future_start.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone34(self):
+        command = PostponeCommand(["-T", "due", "5", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.future + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  5| Future due:{} t:{}\n".format(due.isoformat(), self.future_start.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone35(self):
+        command = PostponeCommand(["-t", "t", "5", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        t = self.future_start + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  5| Future due:{} t:{}\n".format(self.future.isoformat(), t.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone36(self):
+        command = PostponeCommand(["-t", "due", "6", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  6| FutureStart t:{} due:{}\n".format(self.future.isoformat(), due.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone37(self):
+        command = PostponeCommand(["-T", "due", "6", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  6| FutureStart t:{}\n".format(self.future.isoformat()))
+        self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.")
+
+    def test_postpone38(self):
+        command = PostponeCommand(["-t", "t", "6", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        t = self.future + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  6| FutureStart t:{}\n".format(t.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone39(self):
+        command = PostponeCommand(["-t", "due", "7", "1w"], self.todolist, self.out,
+                                  self.error)
         command.execute()
 
         self.assertFalse(self.todolist.dirty)
-        self.assertEqual(self.errors, "Postponing todo item failed: invalid start date.\n")
+        self.assertEqual(self.output, "")
+        self.assertEqual(self.errors, "Postponing todo item failed: invalid due date.\n")
+
+    def test_postpone40(self):
+        command = PostponeCommand(["-T", "due", "7", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        self.assertFalse(self.todolist.dirty)
+        self.assertEqual(self.output, "")
+        self.assertEqual(self.errors, "Postponing todo item failed: invalid due date.\n")
+
+    def test_postpone41(self):
+        command = PostponeCommand(["-t", "due", "8", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        due = self.today + timedelta(7)
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  8| InvalidStartDate due:{} t:2017-06-31\n".format(due.isoformat()))
+        self.assertEqual(self.errors, "")
+
+    def test_postpone42(self):
+        command = PostponeCommand(["-T", "due", "8", "1w"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        self.assertTrue(self.todolist.dirty)
+        self.assertEqual(self.output, "|  8| InvalidStartDate t:2017-06-31\n")
+        self.assertEqual(self.errors, "Warning: todo item has no (valid) due date, therefore it was not adjusted.")
 
     def test_expr_postpone1(self):
         command = PostponeCommand(["-e", "due:tod", "2w"], self.todolist,

--- a/topydo/commands/PostponeCommand.py
+++ b/topydo/commands/PostponeCommand.py
@@ -33,6 +33,7 @@ class PostponeCommand(MultiCommand):
 
         self.move_and_create_tags = set()
         self.move_tags = set()
+        self.todo_modified = False
         self.last_argument = True
 
     def get_flags(self):
@@ -88,11 +89,15 @@ class PostponeCommand(MultiCommand):
                         todo.set_tag(tag, new_due.isoformat())
                         self.todolist.dirty = True
 
+                    self.todo_modified = True
+
                 else:
                     self.error("Invalid date pattern given.")
                     break
 
-            self.out(self.printer.print_todo(todo))
+            if self.todo_modified:
+                self.out(self.printer.print_todo(todo))
+                self.todo_modified = False
 
     def usage(self):
         return """\

--- a/topydo/commands/PostponeCommand.py
+++ b/topydo/commands/PostponeCommand.py
@@ -40,12 +40,12 @@ class PostponeCommand(MultiCommand):
     def get_flags(self):
         return("st:T:", [])
 
-    def process_flag(self, p_opt, p_value):
-        if p_opt == '-s':
+    def process_flag(self, p_option, p_value):
+        if p_option == '-s':
             self.move_start_date = True
-        if p_opt == '-t':
+        if p_option == '-t':
             self.move_and_create_tags.add(p_value)
-        if p_opt == '-T':
+        if p_option == '-T':
             self.move_tags.add(p_value)
 
     def _execute_multi_specific(self):

--- a/topydo/commands/PostponeCommand.py
+++ b/topydo/commands/PostponeCommand.py
@@ -86,8 +86,8 @@ class PostponeCommand(MultiCommand):
                 else:
                     # pylint: disable=E1103
                     todo.set_tag(self.tag, new_due.isoformat())
+                    self.todolist.dirty = True
 
-                self.todolist.dirty = True
                 self.out(self.printer.print_todo(todo))
             else:
                 self.error("Invalid date pattern given.")


### PR DESCRIPTION
In my `todo.txt`, I have many records with a `t:` but no `due:` tag. It would be nice to have a way of postponing start dates without introducing a `due:` tag as a byproduct (which is the current behavior of `postpone -s`). Changing the behavior of `postpone -s` would break backward compatibility, so maybe `postpone -s -s`?

Unfortunately, implementing this occurred to be not so trivial, since in the current code the postponing operation derives the new `t:` from the new `due:`, rather than independently. Moreover, missing `t:` is handled differently than missing `due:`.