### PR TITLE
Add auto_uuid feature

### DIFF
--- a/test/data/ConfigTest4.conf
+++ b/test/data/ConfigTest4.conf
@@ -3,6 +3,7 @@ colors                      = junk
 
 [add]
 auto_creation_date          = junk
+auto_uuid                   = junk
 
 [ls]
 indent                      = junk

--- a/test/test_add_command.py
+++ b/test/test_add_command.py
@@ -395,6 +395,29 @@ class AddCommandTest(CommandTest):
         self.assertEqual(self.todolist.todo(1).source(), "New todo")
         self.assertEqual(self.errors, "")
 
+    def test_add_task_with_auto_uuid(self):
+        config(p_overrides={('add', 'auto_uuid'): '1'})
+
+        args = ["New todo"]
+        command = AddCommand.AddCommand(args, self.todolist, self.out,
+                                        self.error)
+        command.execute()
+
+        self.assertRegex(self.todolist.todo(1).source(), "{tod} New todo uuid:[0-9a-f-]{{36}}".format(tod=self.today))
+        self.assertEqual(self.errors, "")
+        self.assertTrue(self.todolist.todo(1).has_tag("uuid"))
+
+        first_uuid = self.todolist.todo(1).tag_value("uuid")
+
+        command = AddCommand.AddCommand(args, self.todolist, self.out,
+                                        self.error)
+        command.execute()
+
+        self.assertRegex(self.todolist.todo(2).source(), "{tod} New todo uuid:[0-9a-f-]{{36}}".format(tod=self.today))
+        self.assertEqual(self.errors, "")
+        self.assertTrue(self.todolist.todo(2).has_tag("uuid"))
+        self.assertNotEqual(self.todolist.todo(2).tag_value("uuid"), first_uuid)
+
     def test_add_completed(self):
         """ Add a command that is completed automatically. """
         command = AddCommand.AddCommand(["x 2015-01-01 Already completed"],

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -172,5 +172,10 @@ class ConfigTest(TopydoTest):
         self.assertEqual(keymap['k'], 'bar')
         self.assertEqual(keymap['z'], 'foobar')
 
+    def test_config29(self):
+        """ Bad auto uuid switch value. """
+        self.assertEqual(config("test/data/ConfigTest4.conf").auto_uuid(),
+                         bool(int(config().defaults["add"]["auto_uuid"])))
+
 if __name__ == '__main__':
     unittest.main()

--- a/topydo/commands/AddCommand.py
+++ b/topydo/commands/AddCommand.py
@@ -21,6 +21,7 @@ import re
 from datetime import date
 from os.path import expanduser
 from sys import stdin
+from uuid import uuid4
 
 from topydo.lib.Config import config
 from topydo.lib.prettyprinters.Numbers import PrettyPrinterNumbers
@@ -74,6 +75,9 @@ class AddCommand(WriteCommand):
 
         if config().auto_creation_date():
             todo.set_creation_date(date.today())
+
+        if config().auto_uuid():
+            todo.set_tag("uuid", str(uuid4()))
 
         self.out(self.printer.print_todo(todo))
 

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -77,6 +77,7 @@ class _Config:
 
             'add': {
                 'auto_creation_date': '1',
+                'auto_uuid': '0',
             },
 
             'ls': {
@@ -399,6 +400,12 @@ class _Config:
             return self.cp.getboolean('add', 'auto_creation_date')
         except ValueError:
             return self.defaults['add']['auto_creation_date'] == '1'
+
+    def auto_uuid(self):
+        try:
+            return self.cp.getint('add', 'auto_uuid')
+        except ValueError:
+            return self.defaults['add']['auto_uuid'] == '1'
 
     @lru_cache(maxsize=1)
     def aliases(self):


### PR DESCRIPTION
This adds a feature to assign every newly created task a stable uuid to
identify that task later. The uuid is saved as "uuid" tag field.

Signed-off-by: Jan Losinski <losinski@wh2.tu-dresden.de>