### PR TITLE
Add a setup.py test req for freezegun

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ setup(
     install_requires=[
         'arrow >= 0.7.0',
     ],
+    tests_require=[
+        'freezegun',
+    ],
     extras_require={
         ':sys_platform=="win32"': ['colorama>=0.2.5'],
         ':python_version=="3.2"': ['backports.shutil_get_terminal_size>=1.0.0'],


### PR DESCRIPTION
Tell setup.py that freezegun is required for tests.

BTW, I'm getting ~15 test failures that appear to be related to Debian bug [916702](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=916702), an incompatibility between older freezegun and Python 3.7 (Debian unstable).