### PR TITLE
Preserve Vertical Whitespace Option

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -240,6 +240,8 @@ Error message and password prompt
 
 <li>ConfigAutoCreation</li>
 
+<li>ConfigAutoWhitespace</li>
+
 <li>ConfigBackupCount</li>
 
 <li>ConfigColors</li>
@@ -9909,6 +9911,12 @@ Automatically add the creation date to a todo item that is added with the &lt;&l
 
 The creation date is used to determine the length of a todo item, in case the [[start date|TagStart]] is missing.</pre>
 </div>
+<div bag="default" config-default="1" config-description="Automatically remove vertical whitespace on load" config-group="topydo" config-item="auto_delete_whitespace" config-type="Boolean" created="20190107003932467" modified="20190107004209208" revision="0" tags="Configuration" title="ConfigAutoWhitespace" type="text/vnd.tiddlywiki">
+<pre>&lt;&lt;config&gt;&gt;
+
+Automatically remove any line that does not contain a space when loading the todo list. This has the effect of eliminating space left from previously deleted tasks, and any other blank lines in the document.
+</pre>
+</div>
 <div bag="default" config-default="5" config-description="The number of [[backups|Backups]] to make (0 disables backups)" config-group="topydo" config-item="backup_count" config-type="Integer" created="20160520103135844" modified="20160622123411778" revision="0" tags="Configuration" title="ConfigBackupCount" type="text/vnd.tiddlywiki">
 <pre>&lt;&lt;config&gt;&gt;
 
@@ -10392,6 +10400,24 @@ which could result in the graph below:
 The background color is the [[progress color|ProgressColors]] of the corresponding todo item.
 
 The &lt;&lt;cmd dep&gt;&gt; command is also Dot aware, which allows you to generate a specific dependency tree.</pre>
+</div>
+<div bag="default" created="20160625135840359" draft.of="$:/my/macros/ConfigTable" draft.title="$:/my/macros/ConfigTable" modified="20190107003309761" revision="0" tags="$:/tags/Macro" title="Draft of '$:/my/macros/ConfigTable'" type="text/vnd.tiddlywiki">
+<pre>\define configTable()
+&lt;!-- Set variable 'group' to display a table for that configuration group --&gt;
+&lt;table&gt;
+&lt;tr&gt;&lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Type&lt;/th&gt;&lt;th&gt;Default&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;/tr&gt;
+
+&lt;$list filter=&quot;[tag[Configuration]field:config-group[$(group)$]sort[config-item]]&quot; variable=&quot;item&quot;&gt;
+&lt;tr&gt;
+&lt;td&gt;&lt;$link to=&lt;&lt;item&gt;&gt;&gt;&lt;$transclude tiddler=&lt;&lt;item&gt;&gt; field=&quot;config-item&quot;/&gt;&lt;/$link&gt;&lt;/td&gt;
+&lt;td&gt;&lt;$transclude tiddler=&lt;&lt;item&gt;&gt; field=&quot;config-type&quot;/&gt;&lt;/td&gt;
+&lt;td&gt;&lt;$transclude tiddler=&lt;&lt;item&gt;&gt; field=&quot;config-default&quot;/&gt;&lt;/td&gt;
+&lt;td&gt;&lt;$transclude tiddler=&lt;&lt;item&gt;&gt; field=&quot;config-description&quot;/&gt;&lt;/td&gt;
+&lt;/tr&gt;
+&lt;/$list&gt;
+&lt;/table&gt;
+
+\end</pre>
 </div>
 <div bag="default" created="20160715052254901" modified="20160715052254901" revision="0" title="Draft of 'CLI'" type="text/vnd.tiddlywiki">
 <pre></pre>

--- a/test/data/listload.conf
+++ b/test/data/listload.conf
@@ -1,0 +1,2 @@
+[topydo]
+auto_delete_whitespace = 0

--- a/test/data/listload2.conf
+++ b/test/data/listload2.conf
@@ -1,0 +1,2 @@
+[topydo]
+auto_delete_whitespace = invalid

--- a/test/test_todo_list.py
+++ b/test/test_todo_list.py
@@ -509,5 +509,30 @@ class TodoListCleanDependencyTester(TopydoTest):
         self.assertFalse(self.todolist.todo_by_dep_id('1'))
 
 
+class TodoLoadTester(TopydoTest):
+    """Test the auto_delete_whitespace configuration parameter"""
+    def setUp(self):
+        super().setUp()
+        self.todoPath = 'test/data/TodoListTest.txt'
+        self.todofile = TodoFile(self.todoPath)
+
+    def test_load_default(self):
+        todolist = TodoListBase(self.todofile.read())
+
+        self.assertTrue(all([len(todo.source()) != 0 for todo in todolist]))
+
+    def test_load_preserve_ws(self):
+        config("test/data/listload.conf")
+        todolist = TodoListBase(self.todofile.read())
+
+        self.assertTrue(any([len(todo.source()) == 0 for todo in todolist]))
+
+    def test_load_use_default(self):
+        config("test/data/listload2.conf")
+        todolist = TodoListBase(self.todofile.read())
+
+        self.assertTrue(all([len(todo.source()) != 0 for todo in todolist]))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/topydo.conf
+++ b/topydo.conf
@@ -9,6 +9,7 @@ colors                      = auto
 identifiers                 = linenumber
 identifier_alphabet         = 0123456789abcdefghijklmnopqrstuvwxyz
 backup_count                = 5
+auto_delete_whitespace      = 1
 
 [add]
 auto_creation_date          = 1

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -73,6 +73,7 @@ class _Config:
                 'identifiers': 'linenumber',
                 'identifier_alphabet': '0123456789abcdefghijklmnopqrstuvwxyz',
                 'backup_count': '5',
+                'auto_delete_whitespace': '1',
             },
 
             'add': {
@@ -259,6 +260,12 @@ class _Config:
             return value
         except ValueError:
             return int(self.defaults['topydo']['backup_count'])
+
+    def auto_delete_whitespace(self):
+        try:
+            return self.cp.getboolean('topydo', 'auto_delete_whitespace')
+        except ValueError:
+            return self.defaults['topydo']['auto_delete_whitespace'] == '1'
 
     def list_limit(self):
         try:

--- a/topydo/lib/TodoListBase.py
+++ b/topydo/lib/TodoListBase.py
@@ -146,7 +146,9 @@ class TodoListBase(object):
         return todos[0] if len(todos) else None
 
     def add_list(self, p_srcs):
-        todos = [Todo(src) for src in p_srcs if re.search(r'\S', src)]
+        todos = [Todo(src) for src in p_srcs]
+        if config().auto_delete_whitespace():
+            todos = [todo for todo in todos if re.search(r'\S', todo.source())]
         self.add_todos(todos)
 
         return todos


### PR DESCRIPTION
Topydo is insistent on deleting vertical whitespace when loading task files. It doesn't have to do this, and there are [valid reasons](https://github.com/davesteele/todo.txt-gtd) for keeping the space around.

These changes add an auto_delete_whitespace parameter to the 'topydo' section of the conf file, defaulting to true. If not true, blank lines (lines without spaces) are preserved.

The new parameter is documented.