### PR TITLE
edit: Don't move modified todo items to the end of file

### DIFF
--- a/topydo/commands/EditCommand.py
+++ b/topydo/commands/EditCommand.py
@@ -117,10 +117,15 @@ class EditCommand(MultiCommand):
             new_todos = EditCommand._todos_from_temp(temp_todos)
 
             if _is_edited(orig_mtime, temp_todos):
-                for todo in self.todos:
+                modified = list(zip(self.todos, new_todos))
+                for (todo, new_todo) in modified:
+                    self.todolist.modify_todo(todo, new_todo.src)
+                    self.out(self.printer.print_todo(todo))
+
+                for todo in self.todos[len(modified):]:
                     self.todolist.delete(todo, p_leave_tags=True)
 
-                for todo in new_todos:
+                for todo in new_todos[len(modified):]:
                     self.todolist.add_todo(todo)
                     self.out(self.printer.print_todo(todo))
             else:

--- a/topydo/lib/TodoListBase.py
+++ b/topydo/lib/TodoListBase.py
@@ -173,6 +173,13 @@ class TodoListBase(object):
             # todo item couldn't be found, ignore
             pass
 
+    def modify_todo(self, p_todo, p_new_source):
+        """ Modify source of a Todo item from the list. """
+        assert p_todo in self._todos
+        p_todo.set_source_text(p_new_source)
+        self._update_todo_ids()
+        self.dirty = True
+
     def erase(self):
         """ Erases all todos from the list. """
         self._todos = []


### PR DESCRIPTION
Before this patch a `t edit ...` will remove todo items selected by
`...` and then do equivalent of `t add` with input from result of
editing. This works, but has the property that whenever a todo item is
edited, it is always moved till the end of todo.txt file.

This property creates noise and makes synchronization harder to implement for
some of us who uses VCS and different machines to maintain todo.txt .

-> Teach edit to preserve todo items in their places. Adjust existing
tests and add a couple more exercising cases where either new todo
items are added in the editor, or vice versa, removed in the editor.

/cc @mruwek