### PR TITLE
Fix escape deprecation warnings

### DIFF
--- a/test/test_list_format.py
+++ b/test/test_list_format.py
@@ -223,7 +223,7 @@ today | in 2 days | in a day |
         self.assertEqual(self.output, result)
 
     def test_list_format12(self):
-        config(p_overrides={('ls', 'list_format'): '|%I| \%'})
+        config(p_overrides={('ls', 'list_format'): r'|%I| \%'})
         command = ListCommand(["-x"], self.todolist, self.out, self.error)
         command.execute()
 
@@ -501,7 +501,7 @@ x 11 months ago
         self.assertEqual(self.output, result)
 
     def test_list_format33(self):
-        command = ListCommand(["-x", "-s", "desc:priority", "-F", "%{\%p}p{\%p}"], self.todolist, self.out, self.error)
+        command = ListCommand(["-x", "-s", "desc:priority", "-F", r"%{\%p}p{\%p}"], self.todolist, self.out, self.error)
         command.execute()
 
         result = """%pC%p

--- a/topydo/commands/ListCommand.py
+++ b/topydo/commands/ListCommand.py
@@ -215,7 +215,7 @@ class ListCommand(ExpressionCommand):
 [-i <NUMBER 1>[,<NUMBER 2> ...]] [-N | -n <INTEGER>] [EXPRESSION]"""
 
     def help(self):
-        return """\
+        return r"""\
 Lists all relevant todos. A todo is relevant when:
 
 * has not been completed yet,

--- a/topydo/lib/ProgressColor.py
+++ b/topydo/lib/ProgressColor.py
@@ -60,7 +60,7 @@ def progress_color(p_todo):
         if does_recur and due_date and not start_date:
             # add negation, offset is based on due date
             recurrence_pattern = p_todo.tag_value('rec')
-            neg_recurrence_pattern = re.sub('^\+?', '-', recurrence_pattern)
+            neg_recurrence_pattern = re.sub(r'^\+?', '-', recurrence_pattern)
 
             start = relative_date_to_date(neg_recurrence_pattern, due_date)
             result = diff_days(start, due_date)

--- a/topydo/lib/TodoListBase.py
+++ b/topydo/lib/TodoListBase.py
@@ -98,7 +98,7 @@ class TodoListBase(object):
 
             if config().identifiers() != 'text':
                 try:
-                    if re.match('[1-9]\d*', p_identifier):
+                    if re.match(r'[1-9]\d*', p_identifier):
                         # the expression is a string and no leading zeroes,
                         # treat it as an integer
                         raise TypeError


### PR DESCRIPTION
Starting in Python 3.7, Python emits deprecation warning for normal
strings containing what it considers invalid backslash escapes. In
Python 3.9, this situation will be a syntax error. Fix the reported
instances.

ref https://lwn.net/Articles/795546/