### PR TITLE
Set default priority of tasks to 'M' level

### DIFF
--- a/test/data/SorterTest2-result.txt
+++ b/test/data/SorterTest2-result.txt
@@ -1,3 +1,5 @@
+(N) A low priority task
+An unprioritized task
 (C) Useless
 (B) Minor
 (A) Important

--- a/test/data/SorterTest2.txt
+++ b/test/data/SorterTest2.txt
@@ -2,3 +2,5 @@
 (C) Useless
 (A) Important
 (A) Another important task star:1
+An unprioritized task
+(N) A low priority task

--- a/test/data/SorterTest3-result.txt
+++ b/test/data/SorterTest3-result.txt
@@ -2,3 +2,5 @@
 (A) Another important task star:1
 (B) Minor
 (C) Useless
+An unprioritized task
+(N) A low priority task

--- a/test/data/SorterTest3.txt
+++ b/test/data/SorterTest3.txt
@@ -2,3 +2,5 @@
 (C) Useless
 (A) Important
 (A) Another important task star:1
+(N) A low priority task
+An unprioritized task

--- a/test/test_list_format.py
+++ b/test/test_list_format.py
@@ -495,9 +495,9 @@ x 11 months ago
         result = """{C}
 {C}
 {D}
+
+
 {Z}
-
-
 """
         self.assertEqual(self.output, result)
 
@@ -508,9 +508,9 @@ x 11 months ago
         result = """%pC%p
 %pC%p
 %pD%p
+
+
 %pZ%p
-
-
 """
         self.assertEqual(self.output, result)
 
@@ -521,9 +521,9 @@ x 11 months ago
         result = """CC
 CC
 DD
+
+
 ZZ
-
-
 """
         self.assertEqual(self.output, result)
 
@@ -536,9 +536,9 @@ ZZ
         result = """C  C
 C  C
 D  D
+
+
 Z  Z
-
-
 """
         self.assertEqual(self.output, result)
 
@@ -552,9 +552,9 @@ Z  Z
         result = """C   C
 C   C
 D   D
+
+
 Z   Z
-
-
 """
         self.assertEqual(self.output, result)
 
@@ -567,9 +567,9 @@ Z   Z
         result = """   C
    C
    D
+
+
    Z
-
-
 """
         self.assertEqual(self.output, result)
 

--- a/topydo/lib/Sorter.py
+++ b/topydo/lib/Sorter.py
@@ -63,7 +63,7 @@ FIELDS = {
         label='Length',
     ),
     'priority': Field(
-        sort=(lambda t: t.priority() or 'ZZ'),
+        sort=(lambda t: t.priority() or 'M'),
         group=(lambda t: t.priority() or 'None'),
         label='Priority',
     ),


### PR DESCRIPTION
Previously, unprioritized tasks were set below all other tasks. This
change sets unprioritized tasks directly in the middle of all task
prioritizations.

Closes #276 .