### PR TITLE
Fix freezegun in tests

### DIFF
--- a/test/test_list_command.py
+++ b/test/test_list_command.py
@@ -21,6 +21,7 @@ import sys
 import unittest
 from collections import namedtuple
 
+import arrow
 from freezegun import freeze_time
 
 from topydo.commands.ListCommand import ListCommand
@@ -607,7 +608,10 @@ class ListCommandDotTest(CommandTest):
     def setUp(self):
         self.maxDiff = None
 
-    def test_dot(self):
+    @mock.patch('arrow.now') # arrow.now() doesn't freeze at UTC
+    def test_dot(self, mock_arrow):
+        mock_arrow.return_value = arrow.utcnow() # force arrow to UTC
+
         todolist = load_file_to_todolist("test/data/ListCommandDotTest.txt")
 
         command = ListCommand(["-x", "-f", "dot"], todolist, self.out,
@@ -669,7 +673,10 @@ l: 1
 | 5| Different item l:1 test:test_group2
 """)
 
-    def test_group3(self):
+    @mock.patch('arrow.now')
+    def test_group3(self, mock_arrow):
+        mock_arrow.return_value = arrow.utcnow()
+
         todolist = load_file_to_todolist("test/data/ListCommandGroupTest.txt")
 
         command = ListCommand(["-g", "due", "test:test_group3"], todolist, self.out, self.error)
@@ -687,7 +694,10 @@ due: in a day
 | 8| Test 2 test:test_group3 due:2016-12-07
 """)
 
-    def test_group4(self):
+    @mock.patch('arrow.now')
+    def test_group4(self, mock_arrow):
+        mock_arrow.return_value = arrow.utcnow()
+
         todolist = load_file_to_todolist("test/data/ListCommandGroupTest.txt")
 
         command = ListCommand(["-g", "t", "test:test_group4"], todolist, self.out, self.error)
@@ -701,7 +711,10 @@ t: today
 | 9| Test 1 test:test_group4 test:test_group5 t:2016-12-06
 """)
 
-    def test_group5(self):
+    @mock.patch('arrow.now')
+    def test_group5(self, mock_arrow):
+        mock_arrow.return_value = arrow.utcnow()
+
         todolist = load_file_to_todolist("test/data/ListCommandGroupTest.txt")
 
         command = ListCommand(["-x", "-g", "t", "test:test_group5"], todolist, self.out, self.error)

--- a/test/test_list_command.py
+++ b/test/test_list_command.py
@@ -18,7 +18,6 @@ import codecs
 import os
 import re
 import sys
-import time
 import unittest
 from collections import namedtuple
 
@@ -603,7 +602,7 @@ class ListCommandIcalTest(CommandTest):
         self.assertEqual(self.errors, "")
 
 
-@freeze_time('2016-11-17 00:00:00', tz_offset = time.timezone/3600)
+@freeze_time('2016, 11, 17')
 class ListCommandDotTest(CommandTest):
     def setUp(self):
         self.maxDiff = None
@@ -626,7 +625,7 @@ class ListCommandDotTest(CommandTest):
         self.assertEqual(self.errors, "")
 
 
-@freeze_time('2016-12-6 00:00:00', tz_offset = time.timezone/3600)
+@freeze_time('2016, 12, 6')
 class ListCommandGroupTest(CommandTest):
     def test_group1(self):
         todolist = load_file_to_todolist("test/data/ListCommandGroupTest.txt")

--- a/test/test_list_format.py
+++ b/test/test_list_format.py
@@ -17,6 +17,7 @@
 import unittest
 from collections import namedtuple
 
+import arrow
 from freezegun import freeze_time
 
 from topydo.commands.ListCommand import ListCommand
@@ -126,9 +127,11 @@ class ListFormatTest(CommandTest):
 
         self.assertEqual(self.output, result)
 
+    @mock.patch('arrow.now') # arrow.now() doesn't freeze at UTC
     @mock.patch('topydo.lib.ListFormat.get_terminal_size')
-    def test_list_format06(self, mock_terminal_size):
+    def test_list_format06(self, mock_terminal_size, mock_arrow):
         mock_terminal_size.return_value = self.terminal_size(100, 25)
+        mock_arrow.return_value = arrow.utcnow() # force arrow to UTC
 
         config(p_overrides={('ls', 'list_format'): '|%I| %x %p %S %k	%{(}H{)}'})
         command = ListCommand(["-x"], self.todolist, self.out, self.error)
@@ -143,9 +146,11 @@ class ListFormatTest(CommandTest):
 """
         self.assertEqual(self.output, result)
 
+    @mock.patch('arrow.now')
     @mock.patch('topydo.lib.ListFormat.get_terminal_size')
-    def test_list_format07(self, mock_terminal_size):
+    def test_list_format07(self, mock_terminal_size, mock_arrow):
         mock_terminal_size.return_value = self.terminal_size(100, 25)
+        mock_arrow.return_value = arrow.utcnow()
 
         config(p_overrides={('ls', 'list_format'): '|%I| %x %p %S %k	%{(}h{)}'})
         command = ListCommand(["-x"], self.todolist, self.out, self.error)
@@ -177,9 +182,11 @@ x 2014-12-12
 """
         self.assertEqual(self.output, result)
 
+    @mock.patch('arrow.now')
     @mock.patch('topydo.lib.ListFormat.get_terminal_size')
-    def test_list_format09(self, mock_terminal_size):
+    def test_list_format09(self, mock_terminal_size, mock_arrow):
         mock_terminal_size.return_value = self.terminal_size(100, 25)
+        mock_arrow.return_value = arrow.utcnow()
 
         config(p_overrides={('ls', 'list_format'): '%C | %D | %T | %X'})
         command = ListCommand(["-x"], self.todolist, self.out, self.error)
@@ -276,7 +283,10 @@ today | in 2 days | in a day |
 """
         self.assertEqual(self.output, result)
 
-    def test_list_format16(self):
+    @mock.patch('arrow.now')
+    def test_list_format16(self, mock_arrow):
+        mock_arrow.return_value = arrow.utcnow()
+
         command = ListCommand(["-x", "-F", "%C"], self.todolist, self.out, self.error)
         command.execute()
 
@@ -302,7 +312,10 @@ today
 """
         self.assertEqual(self.output, result)
 
-    def test_list_format18(self):
+    @mock.patch('arrow.now')
+    def test_list_format18(self, mock_arrow):
+        mock_arrow.return_value = arrow.utcnow()
+
         command = ListCommand(["-x", "-F", "%D"], self.todolist, self.out, self.error)
         command.execute()
 
@@ -315,7 +328,10 @@ in 2 days
 """
         self.assertEqual(self.output, result)
 
-    def test_list_format19(self):
+    @mock.patch('arrow.now')
+    def test_list_format19(self, mock_arrow):
+        mock_arrow.return_value = arrow.utcnow()
+
         command = ListCommand(["-x", "-F", "%h"], self.todolist, self.out, self.error)
         command.execute()
 
@@ -328,7 +344,10 @@ due in 2 days, starts in a day
 """
         self.assertEqual(self.output, result)
 
-    def test_list_format20(self):
+    @mock.patch('arrow.now')
+    def test_list_format20(self, mock_arrow):
+        mock_arrow.return_value = arrow.utcnow()
+
         command = ListCommand(["-x", "-F", "%H"], self.todolist, self.out, self.error)
         command.execute()
 
@@ -448,7 +467,10 @@ Completed but with
 """
         self.assertEqual(self.output, result)
 
-    def test_list_format29(self):
+    @mock.patch('arrow.now')
+    def test_list_format29(self, mock_arrow):
+        mock_arrow.return_value = arrow.utcnow()
+
         command = ListCommand(["-x", "-F", "%T"], self.todolist, self.out, self.error)
         command.execute()
 
@@ -681,10 +703,12 @@ C -
 """
         self.assertEqual(self.output, result)
 
+    @mock.patch('arrow.now')
     @mock.patch('topydo.lib.ListFormat.get_terminal_size')
-    def test_list_format45(self, mock_terminal_size):
+    def test_list_format45(self, mock_terminal_size, mock_arrow):
         """ Colorblocks should not affect truncating or right_alignment. """
         mock_terminal_size.return_value = self.terminal_size(100, 25)
+        mock_arrow.return_value = arrow.utcnow()
 
         config(p_overrides={('ls', 'list_format'): '%z|%I| %x %p %S %k\\t%{(}h{)}'})
         command = ListCommand(["-x"], self.todolist, self.out, self.error)

--- a/test/test_list_format.py
+++ b/test/test_list_format.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
 import unittest
 from collections import namedtuple
 
@@ -36,7 +35,7 @@ except ImportError:
     import mock
 
 
-@freeze_time("2015-11-06 00:00:00", tz_offset = time.timezone/3600)
+@freeze_time("2015, 11, 06")
 class ListFormatTest(CommandTest):
     def setUp(self):
         super().setUp()

--- a/test/test_revert_command.py
+++ b/test/test_revert_command.py
@@ -16,7 +16,6 @@
 
 import os
 import tempfile
-import time
 import unittest
 from datetime import date
 from glob import glob
@@ -62,7 +61,7 @@ def command_executer(p_cmd, p_args, p_todolist, p_archive=None, *params):
         archive_command.execute()
 
 
-@freeze_time('2015-11-06 00:00:00', tz_offset=time.timezone/3600)
+@freeze_time('2015, 11, 06')
 class RevertCommandTest(CommandTest):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
`arrow.now()` doesn't freeze at UTC (while `datetime` and `date` and `strftime`do). As a result relative/human readable dates were miscalculated in tests. So we have to mock it. Previous resolution introduced in 715a7216b742b46ce7c1cf4b6c5af04fce1031ee fixed tests in some timezones but at the same time breaked couple of them in others. This solution should work everywhere.