### PR TITLE
Better focus in column mode

### DIFF
--- a/topydo.conf
+++ b/topydo.conf
@@ -111,4 +111,5 @@ L = swap_left
 R = swap_right
 <Left> = prev_column
 <Right> = next_column
+<Down> = down
 <Esc> = reset

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -162,6 +162,7 @@ class _Config:
                 'R': 'swap_right',
                 '<Left>': 'prev_column',
                 '<Right>': 'next_column',
+                '<Down>': 'down',
                 '<Esc>': 'reset',
             },
         }

--- a/topydo/ui/columns/Main.py
+++ b/topydo/ui/columns/Main.py
@@ -140,7 +140,8 @@ class UIApplication(CLIApplicationBase):
         self.marked_todos = set()
 
         self.columns = urwid.Columns([], dividechars=0,
-            min_width=config().column_width())
+                                     min_width=config().column_width())
+        self.columns.contents.set_focus_changed_callback(self._move_highlight)
         completer = ColumnCompleter(self.todolist)
         self.commandline = CommandLineWidget(completer, 'topydo> ')
         self.keystate_widget = KeystateWidget()
@@ -267,6 +268,15 @@ class UIApplication(CLIApplicationBase):
 
         self.column_mode = _APPEND_COLUMN
         self._set_alarm_for_next_midnight_update()
+
+    def _move_highlight(self, p_new_focus):
+        """
+        Removes highlight from currently focused column and applies it on
+        column with index equal to p_new_focus.
+        """
+        self.columns.focus.highlight(False)
+        self.columns.contents[p_new_focus][0].highlight(True)
+        self.columns._invalidate()
 
     def _set_alarm_for_next_midnight_update(self):
         def callback(p_loop, p_data):

--- a/topydo/ui/columns/TodoListWidget.py
+++ b/topydo/ui/columns/TodoListWidget.py
@@ -19,6 +19,7 @@ import urwid
 from topydo.lib.HashListValues import max_id_length
 from topydo.lib.Utils import translate_key_to_config
 from topydo.ui.columns.TodoWidget import TodoWidget
+from topydo.ui.columns.Utils import PaletteItem
 
 
 def get_execute_signal(p_prefix):
@@ -40,7 +41,8 @@ class TodoListWidget(urwid.LineBox):
         # store offset length for postpone command (e.g. '3' for 'p3w')
         self._pp_offset = None
 
-        self._title_widget = urwid.Text(p_title, align='center')
+        self._title = urwid.Text(p_title, align='center')
+        self._title_widget = urwid.AttrMap(self._title, PaletteItem.DEFAULT)
 
         self.todolist = urwid.SimpleFocusListWalker([])
         self.listbox = urwid.ListBox(self.todolist)
@@ -78,11 +80,11 @@ class TodoListWidget(urwid.LineBox):
 
     @property
     def title(self):
-        return self._title_widget.text
+        return self._title.text
 
     @title.setter
     def title(self, p_title):
-        self._title_widget.set_text(p_title)
+        self._title.set_text(p_title)
 
     def update(self):
         """
@@ -384,3 +386,9 @@ class TodoListWidget(urwid.LineBox):
             todo_id = None
 
         urwid.emit_signal(self, 'repeat_cmd', todo_id)
+
+    def highlight(self, p_highlight):
+        if p_highlight:
+            self._title_widget.set_attr_map({None: PaletteItem.DEFAULT_FOCUS})
+        else:
+            self._title_widget.set_attr_map({None: PaletteItem.DEFAULT})

--- a/topydo/ui/columns/TodoListWidget.py
+++ b/topydo/ui/columns/TodoListWidget.py
@@ -114,8 +114,15 @@ class TodoListWidget(urwid.LineBox):
                 # -2 for the same reason as in self._scroll_to_bottom()
                 self.todolist.set_focus(len(self.todolist) - 2)
 
+    def _go_down(self, p_size):
+        self.listbox.keypress(p_size, 'down')
+        self.listbox.set_focus_valign('bottom')
+
     def _scroll_to_top(self, p_size):
-        self.listbox.set_focus(0)
+        if isinstance(self.todolist[0], urwid.Text):
+            self.listbox.set_focus(2)
+        else:
+            self.listbox.set_focus(0)
 
         # see comment at _scroll_to_bottom
         self.listbox.calculate_visible(p_size)
@@ -197,7 +204,7 @@ class TodoListWidget(urwid.LineBox):
                 self.listbox.keypress(p_size, 'up')
                 return
             elif p_button == 5:  # down:
-                self.listbox.keypress(p_size, 'down')
+                self._go_down(p_size)
                 return
 
         return super().mouse_event(p_size,  # pylint: disable=E1102
@@ -300,8 +307,10 @@ class TodoListWidget(urwid.LineBox):
 
         if p_action_str in column_actions:
             urwid.emit_signal(self, 'column_action', p_action_str)
-        elif p_action_str in ['up', 'down']:
+        elif p_action_str == 'up':
             self.listbox.keypress(p_size, p_action_str)
+        elif p_action_str == 'down':
+            self._go_down(p_size)
         elif p_action_str == 'home':
             self._scroll_to_top(p_size)
         elif p_action_str == 'end':


### PR DESCRIPTION
This PR does 3 things:

- [x] Properly detects first task in column when `home` action is executed and stops there. Previously it focused on divider between first task and title widget.
- [x] Show the task at the bottom of the column in full.  (fixes: #223)
- [x] Highlight title widget so the user always knows where to move next, even when currently focused column is empty.