### PR TITLE
Respect auto_creation_date when advancing recurring tasks

### DIFF
--- a/test/data/docommand.conf
+++ b/test/data/docommand.conf
@@ -1,0 +1,2 @@
+[add]
+auto_creation_date = 0

--- a/test/test_do_command.py
+++ b/test/test_do_command.py
@@ -18,6 +18,7 @@ import unittest
 from datetime import date, timedelta
 
 from topydo.commands.DoCommand import DoCommand
+from topydo.lib.Config import config
 from topydo.lib.TodoList import TodoList
 
 from .command_testcase import CommandTest
@@ -167,6 +168,16 @@ The following todo item(s) became active:
         result = """Completed: x {today} Strict due:2014-01-01 rec:1d
 The following todo item(s) became active:
 | 12| {today} Strict due:2014-01-02 rec:1d\n""".format(today=self.today)
+        self.assertEqual(self.output, result)
+
+    def test_recurrence_no_creation_date(self):
+        config("test/data/docommand.conf")
+
+        self._recurrence_helper(["4"])
+
+        result = """Completed: x {today} Recurring! rec:1d
+The following todo item(s) became active:
+| 12| Recurring! rec:1d due:{tomorrow}\n""".format(today=self.today, tomorrow=self.tomorrow)
         self.assertEqual(self.output, result)
 
     def test_invalid1(self):

--- a/topydo/lib/Recurrence.py
+++ b/topydo/lib/Recurrence.py
@@ -68,6 +68,7 @@ def advance_recurring_todo(p_todo, p_offset=None, p_strict=False):
         new_start = new_due - timedelta(length)
         todo.set_tag(config().tag_start(), new_start.isoformat())
 
-    todo.set_creation_date(date.today())
+    if config().auto_creation_date():
+        todo.set_creation_date(date.today())
 
     return todo


### PR DESCRIPTION
This PR fixes the problem: when running `topydo do` on a recurring task, the newly created replacement has the creation date even when `auto_creation_date = 0` is configured.