### PR TITLE
Fix typo on ls format specifiers

### DIFF
--- a/topydo/commands/ListCommand.py
+++ b/topydo/commands/ListCommand.py
@@ -256,8 +256,8 @@ When an EXPRESSION is given, only the todos matching that EXPRESSION are shown.
          %P: Priority or placeholder space if no priority.
          %s: Todo text.
          %S: Todo text, truncated such that an item fits on one line.
-         %t: Absolute creation date.
-         %T: Relative creation date.
+         %t: Absolute start date.
+         %T: Relative start date.
          %u: Todo's text-based ID.
          %U: Todo's text-based ID padded with spaces.
          %x: 'x' followed by absolute completion date.


### PR DESCRIPTION
The `%T` and `%t` specifiers are for the date when the todo item is _active_, not when it was created.