### PR TITLE
Fix recurrence of tasks with start date and no due date

### DIFF
--- a/test/test_recurrence.py
+++ b/test/test_recurrence.py
@@ -135,8 +135,22 @@ class RecurrenceTest(TopydoTest):
 
         new_start = date.today() + timedelta(7)
         new_todo = advance_recurring_todo(self.todo)
+        new_due = date.today() + timedelta(7)
 
         self.assertEqual(new_todo.start_date(), new_start)
+        self.assertEqual(new_todo.due_date(), new_due)
+
+    def test_startdate4(self):
+        """ Start date and no due date. """
+        self.todo.set_tag(config().tag_start(), date.today().isoformat())
+
+        new_start = date.today() + timedelta(7)
+        new_todo = advance_recurring_todo(self.todo)
+
+        self.assertEqual(new_todo.start_date(), new_start)
+        self.assertEqual(new_todo.due_date(), None)
+
+
 
     def test_strict_recurrence1(self):
         """

--- a/test/test_recurrence.py
+++ b/test/test_recurrence.py
@@ -178,6 +178,19 @@ class RecurrenceTest(TopydoTest):
 
         self.assertEqual(new_todo.due_date(), new_due)
 
+    def test_strict_recurrence3(self):
+        """
+        Strict recurrence where start date is in the past and there is no due
+        date, using + notation in expression.
+        """
+        past = date.today() - timedelta(8)
+        new_start = date.today() - timedelta(1)
+
+        self.stricttodo.set_tag(config().tag_start(), past.isoformat())
+        new_todo = advance_recurring_todo(self.stricttodo, p_strict=True)
+
+        self.assertEqual(new_todo.start_date(), new_start)
+
     def test_no_recurrence(self):
         self.todo.remove_tag('rec')
         self.assertRaises(NoRecurrenceException, advance_recurring_todo,

--- a/topydo/lib/Recurrence.py
+++ b/topydo/lib/Recurrence.py
@@ -63,10 +63,16 @@ def advance_recurring_todo(p_todo, p_offset=None, p_strict=False):
 
     if (not todo.start_date()) or todo.due_date():
     # pylint: disable=E1103
-      todo.set_tag(config().tag_due(), new_due.isoformat())
-
-    if todo.start_date():
-        new_start = new_due - timedelta(length)
+       todo.set_tag(config().tag_due(), new_due.isoformat())
+       if todo.start_date():
+           new_start = new_due - timedelta(length)
+           todo.set_tag(config().tag_start(), new_start.isoformat())
+    else: #only start date
+        if p_strict:
+            offset = todo.start_date()
+        else:
+            offset = p_offset or date.today()
+        new_start = relative_date_to_date(pattern, offset)
         todo.set_tag(config().tag_start(), new_start.isoformat())
 
     if config().auto_creation_date():

--- a/topydo/lib/Recurrence.py
+++ b/topydo/lib/Recurrence.py
@@ -61,8 +61,9 @@ def advance_recurring_todo(p_todo, p_offset=None, p_strict=False):
     if not new_due:
         raise NoRecurrenceException()
 
+    if (not todo.start_date()) or todo.due_date():
     # pylint: disable=E1103
-    todo.set_tag(config().tag_due(), new_due.isoformat())
+      todo.set_tag(config().tag_due(), new_due.isoformat())
 
     if todo.start_date():
         new_start = new_due - timedelta(length)


### PR DESCRIPTION
Before this change topydo would make a due date on a task without a length giving it a length of 0 days:

```
$topydo add test t:yesterday rec:1d
|  1| 2024-07-13 test t:2024-07-12 rec:1d
$topydo do 1
Completed: x 2024-07-13 2024-07-13 test t:2024-07-12 rec:1d
$cat todo.txt 
2024-07-13 test t:2024-07-14 rec:1d due:2024-07-14
```

with this change it no longer will make a due date in this case:
```
$topydo add test t:yesterday rec:1d
|  1| 2024-07-13 test t:2024-07-12 rec:1d
$topydo do 1
Completed: x 2024-07-13 2024-07-13 test t:2024-07-12 rec:1d
$cat todo.txt 
2024-07-13 test t:2024-07-14 rec:1d
```

This make topydo behave the same way as https://github.com/mpcjanssen/simpletask-android