### PR TITLE
ListFormat: prevent backslash escape corruption and errors in placeholder substitution (#327)

### DIFF
--- a/test/test_list_format.py
+++ b/test/test_list_format.py
@@ -800,5 +800,41 @@ x 2014-12-12 Completed but with date:2014-12-12
         todolist = TodoListBase([str(i) for i in range(0, 100 * 16 * 10)])
         self.assertEqual(4, todolist.max_id_length())
 
+    def test_list_format_backslash(self):
+        """
+        Tasks with backslashes (paths, escapes, backreferences) should not
+        raise ListFormatError or corrupt backreferences in text or tags.
+        """
+        from topydo.lib.TodoList import TodoList
+        todolist = TodoList([
+            r"Check path \Users\test\9",
+            r"Review regex \1 and \g<0>",
+            r"Trailing backslash \\",
+            r"Task with path tag path:C:\Users\test\9",
+        ])
+        command = ListCommand(["-F", "%s %k"], todolist, self.out, self.error)
+        command.execute()
+
+        self.assertIn(r"Check path \Users\test\9", self.output)
+        self.assertIn(r"Review regex \1 and \g<0>", self.output)
+        self.assertIn(r"Trailing backslash \\", self.output)
+        self.assertIn(r"path:C:\Users\test\9", self.output)
+        self.assertEqual(self.errors, "")
+
+    def test_list_format_backslash_truncate(self):
+        """
+        Truncating a task with backslashes should not raise ListFormatError.
+        """
+        from topydo.lib.TodoList import TodoList
+        todolist = TodoList([
+            r"Long path with lots of text \Users\test\folder\subfolder\nested\file.txt",
+        ])
+        with mock.patch('topydo.lib.ListFormat._columns', return_value=30):
+            command = ListCommand(["-F", "%S"], todolist, self.out, self.error)
+            command.execute()
+
+        self.assertIn("...", self.output)
+        self.assertEqual(self.errors, "")
+
 if __name__ == '__main__':
     unittest.main()

--- a/topydo/lib/ListFormat.py
+++ b/topydo/lib/ListFormat.py
@@ -104,7 +104,7 @@ def _truncate(p_str, p_repl):
     """
     # 4 is for '...' and an extra space at the end
     text_lim = _columns() - len(escape_ansi(p_str)) - 4
-    truncated_str = re.sub(re.escape(p_repl), p_repl[:text_lim] + '...', p_str)
+    truncated_str = re.sub(re.escape(p_repl), lambda _: p_repl[:text_lim] + '...', p_str)
 
     return truncated_str
 
@@ -289,7 +289,7 @@ class ListFormatParser(object):
                     substr = re.sub(pattern, '', substr)
                 else:
                     substr = re.sub(pattern, _strip_placeholder_braces, substr)
-                    substr = re.sub(r'(?<!\\)%({ph}|\[{ph}\])'.format(ph=placeholder), repl, substr)
+                    substr = re.sub(r'(?<!\\)%({ph}|\[{ph}\])'.format(ph=placeholder), lambda _: repl, substr)
             except re.error:
                 raise ListFormatError
 


### PR DESCRIPTION
## Summary

Fixes #327

When tasks or tags contain backslashes (such as Windows file paths like `C:\Users\...`, regex syntax like `\1`, `\g<0>`, or trailing backslashes), `topydo ls` previously crashed with:
```
Error while parsing format string (list_format config option or -F)
```

### Cause
In `ListFormatParser.parse()`, `re.sub(r'(?<!\\)%({ph}|\[{ph}\])'.format(ph=placeholder), repl, substr)` passed `repl` as a string argument. Python's `re.sub` parses string replacements for regex escape sequences and group backreferences. When encountering invalid group numbers (`\2`, `\9`), unknown escapes, or trailing backslashes, `re.error` was raised and caught as `ListFormatError`. Even valid backreferences (such as `\1`) were inadvertently substituted with matched groups from the pattern instead of preserving the literal text.

A similar issue existed in `_truncate()`, where `re.sub(re.escape(p_repl), p_repl[:text_lim] + '...', p_str)` passed the replacement string directly.

### Solution
1. Use a callable replacement `lambda _: repl` in `re.sub()`. Per Python's `re` specification, passing a function bypasses template escape/backreference processing and replaces matches with the literal string.
2. Use `lambda _: p_repl[:text_lim] + '...'` in `_truncate()` to prevent escape processing during truncation.
3. Added unit tests in `test/test_list_format.py` verifying backslashes in task text, tags, and during truncation.

## Verification
- Unit tests added in `test/test_list_format.py` pass (`test_list_format_backslash` and `test_list_format_backslash_truncate`).
- Existing test suites in `test.test_todo`, `test.test_filter`, and `test.test_sorter` (98 tests) pass.
- `git diff --check` passes with 0 whitespace errors.
